### PR TITLE
SSR fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 ## Features
 
+- **fixed SSR**
 - fixed `duration` problem, now animation work good.
 - support **scroll down** and **scroll up**
 - support specific scroll container

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,3 @@
-// we use requestAnimationFrame to be called by the browser before every repaint
-const requestAnimationFrame = window.requestAnimationFrame ||
-  window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||
-  function(fn) {
-    window.setTimeout(fn, 16);
-  };
-
-const defaultValue = {
-  duration: 500,
-  offset: 0,
-  container: window
-};
-
 // Get the top position of an element in the document
 const getTop = function(element, start) {
   // return value of html.getBoundingClientRect().top ... IE : 0, other browsers : -pageYOffset
@@ -25,6 +12,19 @@ export default {
         // We do not want this script to be applied in browsers that do not support those
         // That means no smoothscroll on IE9 and below.
         if (typeof window !== 'object' || window.pageYOffset === undefined) return;
+
+        const defaultValue = {
+          duration: 500,
+          offset: 0,
+          container: window
+        };
+
+        // we use requestAnimationFrame to be called by the browser before every repaint
+        const requestAnimationFrame = window.requestAnimationFrame ||
+        window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame ||
+        function(fn) {
+          window.setTimeout(fn, 16);
+        };
 
         let { duration, offset, container } = binding.value;
         duration = duration || defaultValue.duration;


### PR DESCRIPTION
Hello!

With the fix, vue2-smooth-scroll will work in SSR environments as well.

I just moved all the variables and function that accessed `window`, below:

`if (typeof window !== 'object' || window.pageYOffset === undefined) return;`