### PR TITLE
Set output.globalObject to "this" to fix SSR

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,17 +8,18 @@ module.exports = {
   entry: './src/index.js',
   mode: 'production',
   output: {
-    path: resolve("dist"),
+    path: resolve('dist'),
     filename: 'vue-smooth-scroll.min.js',
     library: 'VueSmoothScroll',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   module: {
     rules: [
       {
         test: /\.js$/,
         include: [
-          resolve("src")
+          resolve('src')
         ],
         loader: 'babel-loader'
       }
@@ -27,5 +28,4 @@ module.exports = {
   resolve: {
     extensions: ['js'],
   }
-
 };


### PR DESCRIPTION
As suggested by Webpack's docs: https://webpack.js.org/configuration/output/#outputglobalobject

Without it, I get an error when used with Gridsome:

![image](https://user-images.githubusercontent.com/26761352/79014284-313be900-7b88-11ea-8576-979c24929db5.png)

The error location, `dist/vue-smooth-scroll.min.js@1:210`, is basically where `window` is passed in to the closure by Webpack. Setting the `globalObject` option switches `window` to `this`.

See also: https://github.com/webpack/webpack/issues/6525