### PR TITLE
Take count of scrollMarginTop target style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@ let requestAnimationFrame;
 const getTop = function(element, start) {
   // return value of html.getBoundingClientRect().top ... IE : 0, other browsers : -pageYOffset
   if (element.nodeName === 'HTML') return -start;
-  return element.getBoundingClientRect().top + start;
+
+  const elementTop = element.getBoundingClientRect().top
+  const scrollMarginTop = parseInt(window.getComputedStyle(element).scrollMarginTop || 0, 10)
+  return elementTop + start - scrollMarginTop;
 };
 
 function getDefaultConfig() {


### PR DESCRIPTION
Hello!

I just implemented a fix so that when we scroll, it takes in consideration the "scrollMarginTop" style of the target element.
This property is used with the native anchor scroll, so it's kinda missing with the directive.

The current workaround is to use the `offset` directive parameter, but it isn't as flexible as using the css property made for this.

The `getComputedStyle` method converts units down to `px`, so we always have the right value.
I tested it on a real app with SSR and it's working fine. Feel free to make more tests though, I might not know all the use cases (like horizontal scrolling?)